### PR TITLE
fix(routeToLocation): disable extended uri escaping

### DIFF
--- a/src/parsers/routeToLocation.js
+++ b/src/parsers/routeToLocation.js
@@ -19,7 +19,7 @@ const createMatchRouteToPath = registry => ({ id, params = {}, query = {}, hash 
     let pathname;
 
     try {
-        pathname = matcher(params);
+        pathname = matcher(params, { pretty: true });
     } catch (e) {
         throw new RouterError(e.toString());
     }


### PR DESCRIPTION
For example: node 'c++' will be encoded like this 'c%2B%2B' by default. Pretty option disable this rule.

Disable uri component encode by default.